### PR TITLE
visual changes + api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Simple notifications library for EGUI
 # Usage
 ```rust
 use egui_notify::Toasts;
+use std::time::Duration;
 
 let mut t = Toasts::default();
-t.info("Hello world!", |t| t.with_duration(5.));
+t.info("Hello world!").set_duration(Duration::from_secs(5));
 // ...
 t.show(ctx);
 ```

--- a/egui-notify/src/lib.rs
+++ b/egui-notify/src/lib.rs
@@ -15,6 +15,11 @@ use egui::{vec2, Color32, Context, FontId, Id, LayerId, Order, Rect, Rounding, S
 pub(crate) const TOAST_WIDTH: f32 = 180.;
 pub(crate) const TOAST_HEIGHT: f32 = 34.;
 
+const ERROR_COLOR: Color32 = Color32::from_rgb(200, 90, 90);
+const INFO_COLOR: Color32 = Color32::from_rgb(150, 200, 210);
+const WARNING_COLOR: Color32 = Color32::from_rgb(230, 220, 140);
+const SUCCESS_COLOR: Color32 = Color32::from_rgb(140, 230, 140);
+
 /// Main notifications collector.
 /// # Usage
 /// You need to create [`Toasts`] once and call `.show(ctx)` in every frame.
@@ -36,7 +41,6 @@ pub struct Toasts {
     padding: Vec2,
     reverse: bool,
     speed: f32,
-    default_time: f32,
 
     held: bool,
 }
@@ -49,46 +53,49 @@ impl Toasts {
             margin: vec2(8., 8.),
             toasts: vec![],
             spacing: 8.,
-            padding: vec2(4., 4.),
+            padding: vec2(10., 10.),
             held: false,
             speed: 4.,
             reverse: false,
-            default_time: 5.,
         }
     }
 
     /// Adds new toast to the collection.
     /// By default adds toast at the end of the list, can be changed with `self.reverse`.
-    pub fn add(&mut self, mut toast: Toast) {
-        if toast.expires && toast.duration.is_none() {
-            toast.duration = Some((self.default_time, self.default_time));
-        }
-
+    pub fn add(&mut self, toast: Toast) -> &mut Toast {
         if self.reverse {
             self.toasts.insert(0, toast);
+            return self.toasts.get_mut(0).unwrap()
         } else {
             self.toasts.push(toast);
+            let l = self.toasts.len() - 1;
+            return self.toasts.get_mut(l).unwrap()
         }
     }
 
     /// Shortcut for adding a toast with info `success`.
-    pub fn success(&mut self, caption: impl Into<String>, cb: impl FnOnce(Toast) -> Toast) {
-        self.add(cb(Toast::success(caption)));
+    pub fn success(&mut self, caption: impl Into<String>) -> &mut Toast {
+        self.add(Toast::success(caption))
     }
 
     /// Shortcut for adding a toast with info `level`.
-    pub fn info(&mut self, caption: impl Into<String>, cb: impl FnOnce(Toast) -> Toast) {
-        self.add(cb(Toast::info(caption)));
+    pub fn info(&mut self, caption: impl Into<String>) -> &mut Toast {
+        self.add(Toast::info(caption))
     }
 
     /// Shortcut for adding a toast with warning `level`.
-    pub fn warning(&mut self, caption: impl Into<String>, cb: impl FnOnce(Toast) -> Toast) {
-        self.add(cb(Toast::warning(caption)));
+    pub fn warning(&mut self, caption: impl Into<String>) -> &mut Toast  {
+        self.add(Toast::warning(caption))
     }
 
     /// Shortcut for adding a toast with error `level`.
-    pub fn error(&mut self, caption: impl Into<String>, cb: impl FnOnce(Toast) -> Toast) {
-        self.add(cb(Toast::error(caption)));
+    pub fn error(&mut self, caption: impl Into<String>) -> &mut Toast  {
+        self.add(Toast::error(caption))
+    }
+
+    /// Shortcut for adding a toast with no level.
+    pub fn basic(&mut self, caption: impl Into<String>) -> &mut Toast  {
+        self.add(Toast::basic(caption))
     }
 
     /// Should toasts be added in reverse order?
@@ -140,7 +147,10 @@ impl Toasts {
         let p = ctx.layer_painter(LayerId::new(Order::Foreground, Id::new("toasts")));
 
         let mut remove = None;
-        
+
+        // Remove disappeared toasts
+        toasts.retain(|t| !t.state.disappeared());
+
         // Start disappearing expired toasts
         toasts.iter_mut().for_each(|t| {
             if let Some((_initial_d, current_d)) = t.duration {
@@ -149,9 +159,6 @@ impl Toasts {
                 }
             }
         });
-        
-        // Remove expired toasts
-        toasts.retain(|t| !t.state.disappeared());
 
         // `held` used to prevent sticky removal
         if ctx.input().pointer.primary_released() {
@@ -169,99 +176,121 @@ impl Toasts {
                 }
             }
 
-            let icon_font = FontId::proportional(toast.height - padding.y * 2.);
-
-            let icon_galley = if matches!(toast.level, ToastLevel::Info) {
-                ctx.fonts()
-                    .layout("ℹ".into(), icon_font, Color32::LIGHT_BLUE, f32::INFINITY)
-            } else if matches!(toast.level, ToastLevel::Warning) {
-                ctx.fonts()
-                    .layout("⚠".into(), icon_font, Color32::YELLOW, f32::INFINITY)
-            } else if matches!(toast.level, ToastLevel::Error) {
-                ctx.fonts()
-                    .layout("！".into(), icon_font, Color32::RED, f32::INFINITY)
-            } else if matches!(toast.level, ToastLevel::Success) {
-                ctx.fonts()
-                    .layout("✅".into(), icon_font, Color32::GREEN, f32::INFINITY)
-            } else {
-                unreachable!()
-            };
-            let (icon_width, icon_height) = (icon_galley.rect.width(), icon_galley.rect.height());
-
+            // Create toast label
             let caption_galley = ctx.fonts().layout(
                 toast.caption.clone(),
                 FontId::proportional(16.),
                 Color32::LIGHT_GRAY,
                 f32::INFINITY,
             );
-            let caption_height = caption_galley.rect.height();
 
-            // Expand width if caption is too long
-            toast.width = toast.width.max(
-                icon_galley.rect.width()
-                    + caption_galley.rect.width()
-                    + padding.x * 2.
-                    + icon_width
-                    + 6.,
-            );
+            let (caption_width, caption_height) =
+                (caption_galley.rect.width(), caption_galley.rect.height());
 
-            let anim_offset = toast.width * (1. - toast.value);
-            pos.x += anim_offset * anchor.anim_side();
-            let rect = toast.calc_anchored_rect(pos, *anchor);
-            // Required due to positioning of the next toast
-            pos.x -= anim_offset * anchor.anim_side();
 
-            let toast_hovered = ctx
-                .input()
-                .pointer
-                .hover_pos()
-                .map(|p| rect.contains(p))
-                .unwrap_or(false);
+            // Create toast icon
+            let icon_font = FontId::proportional(toast.height - padding.y * 2.);
+            let icon_galley = if matches!(toast.level, ToastLevel::Info) {
+                Some(
+                    ctx.fonts()
+                        .layout("ℹ".into(), icon_font, INFO_COLOR, f32::INFINITY),
+                )
+            } else if matches!(toast.level, ToastLevel::Warning) {
+                Some(
+                    ctx.fonts()
+                        .layout("⚠".into(), icon_font, WARNING_COLOR, f32::INFINITY),
+                )
+            } else if matches!(toast.level, ToastLevel::Error) {
+                Some(
+                    ctx.fonts()
+                        .layout("！".into(), icon_font, ERROR_COLOR, f32::INFINITY),
+                )
+            } else if matches!(toast.level, ToastLevel::Success) {
+                Some(
+                    ctx.fonts()
+                        .layout("✅".into(), icon_font, SUCCESS_COLOR, f32::INFINITY),
+                )
+            } else {
+                None
+            };
 
-            p.rect_filled(rect, Rounding::same(4.), Color32::from_rgb(30, 30, 30));
+            let (icon_width, icon_height) = if let Some(icon_galley) = icon_galley.as_ref() {
+                (icon_galley.rect.width(), icon_galley.rect.height())
+            } else {
+                (0., 0.)
+            };
 
-            let oy = ((toast.height - padding.y * 2.) - (icon_height - padding.y * 2.)) / 2.;
-            p.galley(rect.min + vec2(padding.x, oy), icon_galley);
-
-            let oy = ((toast.height - padding.y * 2.) - (caption_height - padding.y * 2.)) / 2.;
-            p.galley(
-                rect.min + vec2(padding.x + icon_width + 4., oy),
-                caption_galley,
-            );
-
-            // Draw duration
-            if let Some((initial, current)) = toast.duration {
-                if !toast.state.disappearing() {
-                    p.line_segment(
-                        [
-                            rect.min + vec2(0., toast.height),
-                            rect.max - vec2((1. - (current / initial)) * toast.width, 0.),
-                        ],
-                        Stroke::new(2., Color32::LIGHT_GRAY),
-                    );
-                }
-            }
-
-            // Render cross
-            if toast.closable {
+            // Create closing cross
+            let cross_galley = if toast.closable {
                 let cross_fid = FontId::proportional(toast.height - padding.y * 2.);
                 let cross_galley = ctx.fonts().layout(
                     "❌".into(),
                     cross_fid,
-                    if toast_hovered {
+                    if false {
                         Color32::WHITE
                     } else {
                         Color32::GRAY
                     },
                     f32::INFINITY,
                 );
-                let cross_width = cross_galley.rect.width();
-                let cross_height = cross_galley.rect.height();
-                let cross_rect = cross_galley.rect;
+                Some(cross_galley)
+            } else {
+                None
+            };
 
-                let oy = ((toast.height - padding.y * 2.) - (cross_height - padding.y * 2.)) / 2.;
-                let mut cross_pos = rect.min + vec2(0., oy);
-                cross_pos.x = rect.max.x - cross_width - padding.x;
+            let (cross_width, cross_height) = if let Some(cross_galley) = cross_galley.as_ref() {
+                (cross_galley.rect.width(), cross_galley.rect.height())
+            } else {
+                (0., 0.)
+            };
+
+            let icon_x_padding = (0., 7.);
+            let cross_x_padding = (7., 0.);
+
+            let icon_width_padded = if icon_width == 0. {
+                0.
+            } else {
+                icon_width + icon_x_padding.0 + icon_x_padding.1
+            };
+            let cross_width_padded = if cross_width == 0. {
+                0.
+            } else {
+                cross_width + cross_x_padding.0 + cross_x_padding.1
+            };
+
+            toast.width = icon_width_padded + caption_width + cross_width_padded + (padding.x * 2.);
+            toast.height = icon_height.max(caption_height).max(cross_height) + padding.y * 2.;
+
+            let anim_offset = toast.width * (1. - ease_in_cubic(toast.value));
+            pos.x += anim_offset * anchor.anim_side();
+            let rect = toast.calc_anchored_rect(pos, *anchor);
+
+            // Required due to positioning of the next toast
+            pos.x -= anim_offset * anchor.anim_side();
+
+            // Draw background
+            p.rect_filled(rect, Rounding::same(4.), Color32::from_rgb(30, 30, 30));
+
+            // Paint icon
+            if let Some(icon_galley) = icon_galley {
+                let oy = toast.height / 2. - icon_height / 2.;
+                let ox = padding.x + icon_x_padding.0;
+                p.galley(rect.min + vec2(ox, oy), icon_galley);
+            }
+
+            // Paint caption
+            let oy = toast.height / 2. - caption_height / 2.;
+            let o_from_icon = if icon_width == 0. { 0.} else {icon_width + icon_x_padding.1};
+            let o_from_cross = if cross_width == 0. { 0.} else {cross_width + cross_x_padding.0};
+            let ox = (toast.width / 2. - caption_width / 2.) + o_from_icon / 2. - o_from_cross / 2. ;
+            p.galley(rect.min + vec2(ox, oy), caption_galley);
+
+            // Paint cross
+            if let Some(cross_galley) = cross_galley {
+                let cross_rect = cross_galley.rect;
+                let oy = toast.height / 2. - cross_height / 2.;
+                let ox = toast.width - cross_width - cross_x_padding.1 - padding.x;
+                let cross_pos = rect.min + vec2(ox, oy);
                 p.galley(cross_pos, cross_galley);
 
                 let screen_cross = Rect {
@@ -274,6 +303,19 @@ impl Toasts {
                         remove = Some(i);
                         *held = true;
                     }
+                }
+            }
+
+            // Draw duration
+            if let Some((initial, current)) = toast.duration {
+                if !toast.state.disappearing() {
+                    p.line_segment(
+                        [
+                            rect.min + vec2(0., toast.height),
+                            rect.max - vec2((1. - (current / initial)) * toast.width, 0.),
+                        ],
+                        Stroke::new(2., Color32::LIGHT_GRAY),
+                    );
                 }
             }
 
@@ -292,7 +334,7 @@ impl Toasts {
                 update = true;
                 toast.value -= ctx.input().stable_dt * (*speed);
 
-                if toast.value < 0. {
+                if toast.value <= 0. {
                     toast.state = ToastState::Disappeared;
                 }
             }
@@ -312,4 +354,8 @@ impl Default for Toasts {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn ease_in_cubic(x: f32) -> f32 {
+    1. - (1. - x).powi(3)
 }

--- a/egui-notify/src/lib.rs
+++ b/egui-notify/src/lib.rs
@@ -28,7 +28,7 @@ const SUCCESS_COLOR: Color32 = Color32::from_rgb(140, 230, 140);
 ///
 /// # egui_notify::__run_test_ctx(|ctx| {
 /// let mut t = Toasts::default();
-/// t.info("Hello, World!", |t| t.with_duration(5.));
+/// t.info("Hello, World!").set_duration(Duration::from_secs(5)).set_closable(true);
 /// // More app code
 /// t.show(ctx);
 /// # });

--- a/egui-notify/src/toast.rs
+++ b/egui-notify/src/toast.rs
@@ -15,6 +15,8 @@ pub enum ToastLevel {
 #[derive(Debug)]
 pub(crate) enum ToastState {
     Appear,
+    Disapper,
+    Disappeared,
     Idle,
 }
 
@@ -22,7 +24,12 @@ impl ToastState {
     pub fn appearing(&self) -> bool {
         matches!(self, Self::Appear)
     }
-
+    pub fn disappearing(&self) -> bool {
+        matches!(self, Self::Disapper)
+    }
+    pub fn disappeared(&self) -> bool {
+        matches!(self, Self::Disappeared)
+    }
     pub fn idling(&self) -> bool {
         matches!(self, Self::Idle)
     }

--- a/egui-notify/src/toast.rs
+++ b/egui-notify/src/toast.rs
@@ -1,5 +1,4 @@
 use std::{fmt::Debug, time::Duration};
-
 use crate::{Anchor, TOAST_HEIGHT, TOAST_WIDTH};
 use egui::{pos2, vec2, Pos2, Rect};
 
@@ -143,6 +142,20 @@ impl Toast {
             },
         )
     }
+    
+    /// Set the options with a ToastOptions
+    pub fn set_options(&mut self, options: ToastOptions) -> &mut Self {
+        self.set_closable(options.closable);
+        self.set_duration(options.duration);
+        self.set_level(options.level);
+        self
+    }
+
+    /// Change the level of the toast
+    pub fn set_level(&mut self, level: ToastLevel) -> &mut Self {
+        self.level = level;
+        self
+    }
 
     /// Can use close the toast?
     pub fn set_closable(&mut self, closable: bool) -> &mut Self {
@@ -150,10 +163,14 @@ impl Toast {
         self
     }
 
-    /// In what time should the toast expire?
-    pub fn set_duration(&mut self, duration: Duration) -> &mut Self {
-        let max_dur = duration_to_seconds_f32(duration);
-        self.duration = Some((max_dur, max_dur));
+    /// In what time should the toast expire? Set to `None` for no expiry.
+    pub fn set_duration(&mut self, duration: Option<Duration>) -> &mut Self {
+        if let Some(duration) = duration {
+            let max_dur = duration_to_seconds_f32(duration);
+            self.duration = Some((max_dur, max_dur));
+        } else {
+            self.duration = None;
+        }
         self
     }
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,5 +1,10 @@
-use eframe::{App, egui::{Context, Style, Window, Slider}, Frame, NativeOptions};
-use egui_notify::{Toasts, Toast, Anchor};
+use std::time::Duration;
+
+use eframe::{
+    egui::{Context, Slider, Style, Window},
+    App, Frame, NativeOptions,
+};
+use egui_notify::{Anchor, Toast, Toasts};
 
 struct ExampleApp {
     toasts: Toasts,
@@ -10,50 +15,59 @@ struct ExampleApp {
 
 impl App for ExampleApp {
     fn update(&mut self, ctx: &Context, _: &mut Frame) {
-        Window::new("Controls")
-            .show(ctx, |ui| {
-                ui.text_edit_singleline(&mut self.caption);
-                ui.horizontal(|ui| {
-                    ui.label("Duration (in s)");
-                    ui.add(Slider::new(&mut self.duration, 1.0..=10.0));
-                });
-                ui.checkbox(&mut self.closable, "Closable");
-
-                let cb = |t: Toast| t.closable(self.closable).with_duration(self.duration);
-
-                ui.horizontal(|ui| {
-                    if ui.button("Success").clicked() {
-                        self.toasts.success(self.caption.clone(), cb);
-                    }
-
-                    if ui.button("Info").clicked() {
-                        self.toasts.info(self.caption.clone(), cb);
-                    }
-    
-                    if ui.button("Warning").clicked() {
-                        self.toasts.warning(self.caption.clone(), cb);
-                    }
-    
-                    if ui.button("Error").clicked() {
-                        self.toasts.error(self.caption.clone(), cb);
-                    }
-                });
+        Window::new("Controls").show(ctx, |ui| {
+            ui.text_edit_singleline(&mut self.caption);
+            ui.horizontal(|ui| {
+                ui.label("Duration (in s)");
+                ui.add(Slider::new(&mut self.duration, 1.0..=10.0));
             });
+            ui.checkbox(&mut self.closable, "Closable");
+
+            let cb = |t: &mut Toast| {
+                t.set_closable(self.closable)
+                    .set_duration(Duration::from_millis((1000. * self.duration) as u64));
+            };
+
+            ui.horizontal(|ui| {
+                if ui.button("Success").clicked() {
+                    cb(self.toasts.success(self.caption.clone()));
+                }
+
+                if ui.button("Info").clicked() {
+                    cb(self.toasts.info(self.caption.clone()));
+                }
+
+                if ui.button("Warning").clicked() {
+                    cb(self.toasts.warning(self.caption.clone()));
+                }
+
+                if ui.button("Error").clicked() {
+                    cb(self.toasts.error(self.caption.clone()));
+                }
+
+                if ui.button("Basic").clicked() {
+                    cb(self.toasts.basic(self.caption.clone()));
+                }
+            });
+        });
 
         self.toasts.show(ctx);
     }
 }
 
 fn main() {
-    eframe::run_native("example", NativeOptions::default(), Box::new(|cc| {
-        cc.egui_ctx.set_style(Style::default());
+    eframe::run_native(
+        "example",
+        NativeOptions::default(),
+        Box::new(|cc| {
+            cc.egui_ctx.set_style(Style::default());
 
-        Box::new(ExampleApp {
-            caption: "Hello! It's caption".into(),
-            toasts: Toasts::default()
-                .with_anchor(Anchor::TopRight),
-            closable: true,
-            duration: 3.5,
-        })
-    }));
+            Box::new(ExampleApp {
+                caption: "Hello! It's caption".into(),
+                toasts: Toasts::default().with_anchor(Anchor::TopRight),
+                closable: true,
+                duration: 3.5,
+            })
+        }),
+    );
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+
 use eframe::{
     egui::{Context, Slider, Style, Window},
     App, Frame, NativeOptions,

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,6 +1,4 @@
 use std::time::Duration;
-
-
 use eframe::{
     egui::{Context, Slider, Style, Window},
     App, Frame, NativeOptions,
@@ -26,7 +24,7 @@ impl App for ExampleApp {
 
             let cb = |t: &mut Toast| {
                 t.set_closable(self.closable)
-                    .set_duration(Duration::from_millis((1000. * self.duration) as u64));
+                    .set_duration(Some(Duration::from_millis((1000. * self.duration) as u64)));
             };
 
             ui.horizontal(|ui| {


### PR DESCRIPTION
visual changes
---
 - icons smaller, desaturated
 - spacing of icons relative to text more consistent
 - toast will shrink/enlarge with caption text (did not shrink before)
 - toast now animates disappearance
   - *after* toast runs out of time, it will run the disappearing animation; so technically the toast will be visible for slightly longer than the set duration
 - toast uses cubic easing for sliding animations

api changes
---
 - new `ToastOptions` as well as `ToastOptions::default()` to create toasts easier
  - `Toast::new` signature is now `fn new(caption: impl Into<String>, options: ToastOptions) -> Self`
 - `Toasts` no longer takes `cb` closure for setting toast options in shortcut functions
 - `Toasts::add` (as well as shortcut functions like `Toasts::info`) now returns mutable reference to added toast
 - `Toast` functions that used to consume `Toast` now just use the mutable reference (eg `fn with_modification(mut Toast) -> Self` changed to `fn set_modification(&mut Toast) -> &mut Self`
 - above two changes allow toast settings to be chained with modification functions from the `Toasts` shortcut functions