### PR TITLE
Added Custom Toast Level

### DIFF
--- a/examples/all.rs
+++ b/examples/all.rs
@@ -16,6 +16,8 @@ struct ExampleApp {
     duration: f32,
     font_size: f32,
     dark: bool,
+    custom_level_string: String,
+    custom_level_color: egui::Color32,
 }
 
 impl App for ExampleApp {
@@ -38,6 +40,8 @@ impl App for ExampleApp {
                     ui.add(Slider::new(&mut self.font_size, 8.0..=20.0));
                 });
             });
+            ui.text_edit_singleline(&mut self.custom_level_string);
+            ui.color_edit_button_srgba(&mut self.custom_level_color);
 
             let customize_toast = |t: &mut Toast| {
                 let duration = if self.expires {
@@ -70,6 +74,10 @@ impl App for ExampleApp {
 
                 if ui.button("Basic").clicked() {
                     customize_toast(self.toasts.basic(self.caption.clone()));
+                }
+
+                if ui.button("Custom").clicked() {
+                    customize_toast(self.toasts.custom(self.caption.clone(), self.custom_level_string.clone(), self.custom_level_color));
                 }
             });
 
@@ -130,6 +138,8 @@ And another one"#
                 duration: 3.5,
                 dark: true,
                 font_size: 16.,
+                custom_level_string: "$".into(),
+                custom_level_color: egui::Color32::GREEN,
             })
         }),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@ impl Toasts {
         self.add(Toast::basic(caption))
     }
 
+    /// Shortcut for adding a toast with custom `level`.
+    pub fn custom(&mut self, caption: impl Into<String>, level_string: String, level_color: egui::Color32) -> &mut Toast {
+        self.add(Toast::custom(caption, ToastLevel::Custom(level_string, level_color)))
+    }
+
     /// Should toasts be added in reverse order?
     pub const fn reverse(mut self, reverse: bool) -> Self {
         self.reverse = reverse;
@@ -233,16 +238,23 @@ impl Toasts {
 
             // Create toast icon
             let icon_font = FontId::proportional(icon_width);
-            let icon_galley = if matches!(toast.level, ToastLevel::Info) {
-                Some(ctx.fonts(|f| f.layout("ℹ".into(), icon_font, INFO_COLOR, f32::INFINITY)))
-            } else if matches!(toast.level, ToastLevel::Warning) {
-                Some(ctx.fonts(|f| f.layout("⚠".into(), icon_font, WARNING_COLOR, f32::INFINITY)))
-            } else if matches!(toast.level, ToastLevel::Error) {
-                Some(ctx.fonts(|f| f.layout("！".into(), icon_font, ERROR_COLOR, f32::INFINITY)))
-            } else if matches!(toast.level, ToastLevel::Success) {
-                Some(ctx.fonts(|f| f.layout("✅".into(), icon_font, SUCCESS_COLOR, f32::INFINITY)))
-            } else {
-                None
+            let icon_galley = match &toast.level {
+                ToastLevel::Info => Some(ctx.fonts(|f| {
+                    f.layout("ℹ".into(), icon_font, INFO_COLOR, f32::INFINITY)
+                })),
+                ToastLevel::Warning => Some(ctx.fonts(|f| {
+                    f.layout("⚠".into(), icon_font, WARNING_COLOR, f32::INFINITY)
+                })),
+                ToastLevel::Error => Some(ctx.fonts(|f| {
+                    f.layout("！".into(), icon_font, ERROR_COLOR, f32::INFINITY)
+                })),
+                ToastLevel::Success => Some(ctx.fonts(|f| {
+                    f.layout("✅".into(), icon_font, SUCCESS_COLOR, f32::INFINITY)
+                })),
+                ToastLevel::Custom(s, c) => Some(ctx.fonts(|f| {
+                    f.layout(s.clone(), icon_font, *c, f32::INFINITY)
+                })),
+                ToastLevel::None => None,
             };
 
             let (action_width, action_height) = if let Some(icon_galley) = icon_galley.as_ref() {

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -3,7 +3,7 @@ use egui::{pos2, vec2, FontId, Pos2, Rect};
 use std::{fmt::Debug, time::Duration};
 
 /// Level of importance
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum ToastLevel {
     Info,
@@ -11,6 +11,7 @@ pub enum ToastLevel {
     Error,
     Success,
     None,
+    Custom(String, egui::Color32),
 }
 
 impl Default for ToastLevel {
@@ -149,6 +150,17 @@ impl Toast {
             ToastOptions {
                 closable: false,
                 level: ToastLevel::Error,
+                ..ToastOptions::default()
+            },
+        )
+    }
+
+    /// Creates new custom toast, can be closed by default.
+    pub fn custom(caption: impl Into<String>, level: ToastLevel) -> Self {
+        Self::new(
+            caption,
+            ToastOptions {
+                level,
                 ..ToastOptions::default()
             },
         )


### PR DESCRIPTION
A simple addition of a "custom" toast level where users can specify the icon string and colour.
Works very well together with crates like
https://crates.io/crates/egui_phosphor
and
https://crates.io/crates/egui_nerdfonts