### PR TITLE
Rename functions 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 path = "src/lib.rs"
 
 [dependencies]
-egui = { version = "0.28.0", default-features = false }
+egui = { version = "0.28", default-features = false }
 
 [dev-dependencies]
-eframe = { version = "0.28.0", default-features = false, features = [
+eframe = { version = "0.28", default-features = false, features = [
     "default_fonts",
     "glow",
 ] }
@@ -26,4 +26,6 @@ unsafe_code = "forbid"
 
 [lints.clippy]
 all = { level = "deny", priority = 0 }
+unwrap_used = { level = "deny", priority = 1 }
+expect_used = { level = "deny", priority = 1 }
 enum_glob_use = { level = "deny", priority = 2 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ let mut toasts = Toasts::default();
 
 ```rust
 // somewhere within [egui::App::update]...
-toasts.info("Hello world!").set_duration(Duration::from_secs(5));
+toasts.info("Hello world!").duration(Duration::from_secs(5));
 // ...
 toasts.show(ctx);
 ```

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -49,10 +49,10 @@ impl App for ExampleApp {
                 } else {
                     None
                 };
-                t.set_closable(self.closable)
-                    .set_duration(duration)
-                    .set_show_progress_bar(self.show_progress_bar)
-                    .set_font(FontId::proportional(self.font_size));
+                t.closable(self.closable)
+                    .duration(duration)
+                    .show_progress_bar(self.show_progress_bar)
+                    .font(FontId::proportional(self.font_size));
             };
 
             ui.horizontal(|ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ const SUCCESS_COLOR: Color32 = Color32::from_rgb(140, 230, 140);
 ///
 /// # egui_notify::__run_test_ctx(|ctx| {
 /// let mut t = Toasts::default();
-/// t.info("Hello, World!").set_duration(Some(Duration::from_secs(5))).set_closable(true);
+/// t.info("Hello, World!").duration(Some(Duration::from_secs(5))).closable(true);
 /// // More app code
 /// t.show(ctx);
 /// # });
@@ -43,7 +43,6 @@ pub struct Toasts {
     reverse: bool,
     speed: f32,
     font: Option<FontId>,
-
     held: bool,
 }
 
@@ -66,6 +65,7 @@ impl Toasts {
 
     /// Adds new toast to the collection.
     /// By default adds toast at the end of the list, can be changed with `self.reverse`.
+    #[allow(clippy::unwrap_used)] // We know that the index is valid
     pub fn add(&mut self, toast: Toast) -> &mut Toast {
         if self.reverse {
             self.toasts.insert(0, toast);

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -172,40 +172,40 @@ impl Toast {
     }
 
     /// Set the options with a [`ToastOptions`]
-    pub fn set_options(&mut self, options: ToastOptions) -> &mut Self {
-        self.set_closable(options.closable);
-        self.set_duration(options.duration);
-        self.set_level(options.level);
+    pub fn options(&mut self, options: ToastOptions) -> &mut Self {
+        self.closable(options.closable);
+        self.duration(options.duration);
+        self.level(options.level);
         self
     }
 
     /// Change the level of the toast
-    pub fn set_level(&mut self, level: ToastLevel) -> &mut Self {
+    pub fn level(&mut self, level: ToastLevel) -> &mut Self {
         self.level = level;
         self
     }
 
     /// Changes the font used to draw the caption, it takes precedence over the value from
     /// [`Toasts`].
-    pub fn set_font(&mut self, font: FontId) -> &mut Self {
+    pub fn font(&mut self, font: FontId) -> &mut Self {
         self.font = Some(font);
         self
     }
 
-    /// Can use close the toast?
-    pub fn set_closable(&mut self, closable: bool) -> &mut Self {
+    /// Can the user close the toast?
+    pub fn closable(&mut self, closable: bool) -> &mut Self {
         self.closable = closable;
         self
     }
 
     /// Should a progress bar be shown?
-    pub fn set_show_progress_bar(&mut self, show_progress_bar: bool) -> &mut Self {
+    pub fn show_progress_bar(&mut self, show_progress_bar: bool) -> &mut Self {
         self.show_progress_bar = show_progress_bar;
         self
     }
 
     /// In what time should the toast expire? Set to `None` for no expiry.
-    pub fn set_duration(&mut self, duration: Option<Duration>) -> &mut Self {
+    pub fn duration(&mut self, duration: Option<Duration>) -> &mut Self {
         if let Some(duration) = duration {
             let max_dur = duration_to_seconds_f32(duration);
             self.duration = Some((max_dur, max_dur));
@@ -216,13 +216,13 @@ impl Toast {
     }
 
     /// Toast's box height
-    pub fn set_height(&mut self, height: f32) -> &mut Self {
+    pub fn height(&mut self, height: f32) -> &mut Self {
         self.height = height;
         self
     }
 
     /// Toast's box width
-    pub fn set_width(&mut self, width: f32) -> &mut Self {
+    pub fn width(&mut self, width: f32) -> &mut Self {
         self.width = width;
         self
     }


### PR DESCRIPTION
## **Breaking Changes**

I renamed the functions to not have `set_` infant anymore to have the same styling as egui

