### PR TITLE
feat: Add option to draw shadow behind toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * (breaking) Updated to egui `0.29`.
 * (breaking) Renamed functions, removed `set_` prefix to fit egui style. [#29]
 * Accept either `None` or `Some(duration)` in `set_duration`. [#31]
+* Enable shadow beneath `Toasts` using `with_shadow` [#33]
 
 [#29]: https://github.com/ItsEthra/egui-notify/pull/29
 [#31]: https://github.com/ItsEthra/egui-notify/pull/31
+[#33]: https://github.com/ItsEthra/egui-notify/pull/33

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -3,7 +3,7 @@ use eframe::{
     egui::{Context, Slider, Window},
     App, Frame, NativeOptions,
 };
-use egui::{FontId, Style, Visuals};
+use egui::{Color32, FontId, Shadow, Style, Visuals};
 use egui_notify::{Toast, Toasts};
 use std::time::Duration;
 
@@ -18,6 +18,7 @@ struct ExampleApp {
     dark: bool,
     custom_level_string: String,
     custom_level_color: egui::Color32,
+    shadow: bool,
 }
 
 impl App for ExampleApp {
@@ -27,6 +28,18 @@ impl App for ExampleApp {
             ui.checkbox(&mut self.expires, "Expires");
             ui.checkbox(&mut self.closable, "Closable");
             ui.checkbox(&mut self.show_progress_bar, "ShowProgressBar");
+            ui.checkbox(&mut self.shadow, "Shadow").clicked().then(|| {
+                self.toasts = if self.shadow {
+                    Toasts::default().with_shadow(Shadow {
+                        offset: Default::default(),
+                        blur: 30.0,
+                        spread: 5.0,
+                        color: Color32::from_black_alpha(70),
+                    })
+                } else {
+                    Toasts::default()
+                };
+            });
             if !(self.expires || self.closable) {
                 ui.label("Warning; toasts will have to be closed programatically");
             }
@@ -157,6 +170,7 @@ And another one"#
                 font_size: 16.,
                 custom_level_string: "$".into(),
                 custom_level_color: egui::Color32::GREEN,
+                shadow: true,
             }))
         }),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,9 @@ pub use anchor::*;
 
 #[doc(hidden)]
 pub use egui::__run_test_ctx;
-use egui::{vec2, Color32, Context, FontId, Id, LayerId, Order, Rect, Rounding, Stroke, Vec2};
+use egui::{
+    vec2, Color32, Context, FontId, Id, LayerId, Order, Rect, Rounding, Shadow, Stroke, Vec2,
+};
 
 pub(crate) const TOAST_WIDTH: f32 = 180.;
 pub(crate) const TOAST_HEIGHT: f32 = 34.;
@@ -43,7 +45,7 @@ pub struct Toasts {
     reverse: bool,
     speed: f32,
     font: Option<FontId>,
-
+    shadow: Option<Shadow>,
     held: bool,
 }
 
@@ -61,6 +63,7 @@ impl Toasts {
             speed: 4.,
             reverse: false,
             font: None,
+            shadow: None,
         }
     }
 
@@ -159,6 +162,12 @@ impl Toasts {
         self
     }
 
+    /// Enables the use of a shadow for toasts.
+    pub const fn with_shadow(mut self, shadow: Shadow) -> Self {
+        self.shadow = Some(shadow);
+        self
+    }
+
     /// Padding or distance from toasts' bounding boxes to inner contents.
     pub const fn with_padding(mut self, padding: Vec2) -> Self {
         self.padding = padding;
@@ -250,6 +259,7 @@ impl Toasts {
 
             let line_count = toast.caption.chars().filter(|c| *c == '\n').count() + 1;
             let icon_width = caption_height / line_count as f32;
+            let rounding = Rounding::same(4.);
 
             // Create toast icon
             let icon_font = FontId::proportional(icon_width);
@@ -322,8 +332,14 @@ impl Toasts {
             // Required due to positioning of the next toast
             pos.x -= anim_offset * anchor.anim_side();
 
+            // Draw shadow
+            if let Some(shadow) = self.shadow {
+                let s = shadow.as_shape(rect, rounding);
+                p.add(s);
+            }
+
             // Draw background
-            p.rect_filled(rect, Rounding::same(4.), visuals.bg_fill);
+            p.rect_filled(rect, rounding, visuals.bg_fill);
 
             // Paint icon
             if let Some((icon_galley, true)) =


### PR DESCRIPTION
This PR exposes the option to use a shadow on notifications in order to improve visibility. The shadow is optional.