### PR TITLE
Add `len` & `is_empty` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `len` & `is_empty` functions
+
 # 0.17.0
 * (breaking) removed `Toast::font(font: FontId)`, this can now be done by using `egui::widget_text::RichText` and `RichText::font`. [#34]
 * Added support for `egui::widget_text::WidgetText` in Toasts, this allows for more customization of the text in the toast. [#34]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,16 @@ impl Toasts {
         }
     }
 
+    /// Returns the number of toast items.
+    pub fn len(&self) -> usize {
+        self.toasts.len()
+    }
+
+    /// Returns `true` if there are no toast items.
+    pub fn is_empty(&self) -> bool {
+        self.toasts.is_empty()
+    }
+
     /// Shortcut for adding a toast with info `success`.
     pub fn success(&mut self, caption: impl Into<WidgetText>) -> &mut Toast {
         self.add(Toast::success(caption))


### PR DESCRIPTION
There is currently no way to know how many toasts are active, making `dismiss_oldest_toast` only useful if you want exactly one toast.

But I'd like to have like at most 10 toasts or similar