### PR TITLE
Add `Some()` around `Duration` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ let mut toasts = Toasts::default();
 
 ```rust
 // somewhere within [egui::App::update]...
-toasts.info("Hello world!").duration(Duration::from_secs(5));
+toasts.info("Hello world!").duration(Some(Duration::from_secs(5)));
 // ...
 toasts.show(ctx);
 ```


### PR DESCRIPTION
There must have been some API changes, I had to put `Some()` around the `Duration` to compile this.